### PR TITLE
Migration to Python 3, PyHandle and EL9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,17 @@ FILES=check_epic_api.py epicclient.py check_handle_resolution.pl check_handle_ap
 
 PKGVERSION=$(shell grep -s '^Version:' $(SPECFILE) | sed -e 's/Version:\s*//')
 
+srpm: dist
+	rpmbuild -ts ${PKGNAME}-${PKGVERSION}.tar.gz
+	rm ${PKGNAME}-${PKGVERSION}.tar.gz
+
 rpm: dist
 	rpmbuild -ta ${PKGNAME}-${PKGVERSION}.tar.gz
+	rm ${PKGNAME}-${PKGVERSION}.tar.gz
+
+rpm_with_epic: dist
+	rpmbuild -ta ${PKGNAME}-${PKGVERSION}.tar.gz --with epicapi 
+	rm ${PKGNAME}-${PKGVERSION}.tar.gz
 
 dist:
 	rm -rf dist

--- a/README.md
+++ b/README.md
@@ -1,45 +1,11 @@
 # argo-probe-eudat-b2handles
-Two nagios probes are available, `check_epic_api.py` and `check_handle_resolution.pl`.
-
-## check_epic_api.py
-
-This plugin is a simple CRUD test of the EPIC API service on the specified host and the specified prefix. It creates a handle named NAGIOS-{DATE}-{TIME}, and then tries to read it and update it with a new value, and finally tries to delete it.
-
-It imports the `epicclient` module.
-
-### Required options:
-
-`--username, -U <user>` : The username used to authenticate with the EPIC service
-
-`--url, -u <uri>` : The base URI of the EPIC API service to be tested
-
-`--pass, -P <key>` : The API key of the username
-
-`--prefix, -p <prefix>` : The prefix to be tested
-
-
-### Optional options
-
-`--debug, -d` : Debug mode
-
-`--help, -h` : Print a help message and exit
-
-`--timeout, -t <timeout>` : Timeout, in seconds
-
-### Example:
-```
-check_epic_api.py \
-
-	--url "https://epic.domain.com/api/v2/handles/" --prefix 12345 \
-
-	--username nagios --pass deadbabe --debug
-```
+Three nagios probes are available: `check_handle_api.py`, `check_handle_resolution.pl` and optionally `check_epic_api.py`.
 
 ## check_handle_api.py
 
 This plugin is a simple CRUD test of the Handle v8 JSON REST API service on the specified host and the specified prefix. It creates a handle named NAGIOS-{DATE}-{TIME}, and then tries to read it and update it with a new value, and finally tries to delete it.
 
-It uses the b2handle library (http://eudat-b2safe.github.io/B2HANDLE/handleclient.html#).
+It uses the PyHandle library (https://github.com/EUDAT-B2HANDLE/PYHANDLE).
 
 ### Required option:
 
@@ -94,31 +60,63 @@ check_handle_resolution.pl --prefix 12345 --debug
 check_handle_resolution.pl --prefix 12345 --suffix MY_HANDLE --debug --timeout 10
 ```
 
-## Makefile
-`make srpm` : Builds a source RPM package compatible with Red Hat Enterprise Linux 6.
+## check_epic_api.py
 
-`make rpm` : Builds a binary RPM package compatible with Red Hat Enterprise Linux 6.
+This plugin is a simple CRUD test of the EPIC API service on the specified host and the specified prefix. It creates a handle named NAGIOS-{DATE}-{TIME}, and then tries to read it and update it with a new value, and finally tries to delete it.
+
+It imports the `epicclient` module.
+
+### Required options:
+
+`--username, -U <user>` : The username used to authenticate with the EPIC service
+
+`--url, -u <uri>` : The base URI of the EPIC API service to be tested
+
+`--pass, -P <key>` : The API key of the username
+
+`--prefix, -p <prefix>` : The prefix to be tested
+
+
+### Optional options
+
+`--debug, -d` : Debug mode
+
+`--help, -h` : Print a help message and exit
+
+`--timeout, -t <timeout>` : Timeout, in seconds
+
+### Example:
+```
+check_epic_api.py \
+
+	--url "https://epic.domain.com/api/v2/handles/" --prefix 12345 \
+
+	--username nagios --pass deadbabe --debug
+```
+
+## Makefile
+`make srpm` : Builds a source RPM package compatible with Red Hat Enterprise Linux 9.
+
+`make rpm` : Builds a binary RPM package compatible with Red Hat Enterprise Linux 9.
+
+`make rpm_with_epic` : Builds a binary RPM package that includes the check_epic_api.py probe and is compatible with Red Hat Enterprise Linux 9.
 
 ## Dependencies
 
 The following dependencies are automatically installed by rpm :
 
-### check_epic_api.py dependencies
+### check_handle_api_py dependencies
 
 OS repository:
 
 ```
-python
-python-argparse
-python-lxml
-python-simplejson
+python3
 ```
 
-EPEL repository:
+ARGO repository:
 
 ```
-python-defusedxml
-python-httplib2
+pyhandle
 ```
 
 ### check_handle_resolution.pl dependencies
@@ -126,6 +124,24 @@ python-httplib2
 OS repository:
 
 ```
-perl
+perl-interprater
 perl-JSON
 ```
+
+### check_epic_api.py dependencies
+
+OS repository:
+
+```
+python3
+python3-lxml
+```
+
+EPEL repository:
+
+```
+python3-defusedxml
+python3-httplib2
+python3-simplejson
+```
+

--- a/argo-probe-eudat-b2handle.spec
+++ b/argo-probe-eudat-b2handle.spec
@@ -1,6 +1,6 @@
 Name:		argo-probe-eudat-b2handle
-Version:	0.9
-Release:	4%{?dist}
+Version:	1.0
+Release:	0%{?dist}
 Summary:	Monitoring Metrics for B2HANDLE 
 License:	GPLv3+
 Packager:	Kyriakos Gkinis <kyrginis@admin.grnet.gr>
@@ -9,18 +9,20 @@ Source:		%{name}-%{version}.tar.gz
 BuildArch:	noarch
 BuildRoot:	%{_tmppath}/%{name}-%{version}
 
-Requires:	python
-Requires:	python-argparse
-Requires:	python-lxml
-Requires:	python-simplejson
-Requires:	perl
+Requires:	python3
+Requires:	pyhandle
+Requires:	perl-interpreter
 Requires:	perl-JSON
 
-Requires:	python-defusedxml
-Requires:	python-httplib2
+# Create an option to build with epic api probe, default is without
+%bcond_with epicapi
 
-%if "%{?dist}" == ".el7"
-Requires:	b2handle
+%if %{with epicapi}
+BuildRequires:	python3-devel
+Requires:	python3-lxml
+Requires:	python3-defusedxml
+Requires:	python3-httplib2
+Requires:	python3-simplejson
 %endif
 
 %description
@@ -35,9 +37,12 @@ Monitoring metrics to check functionality of Handle service and EPIC API
 
 install -d %{buildroot}/%{_libexecdir}/argo/probes/eudat-b2handle
 install -m 755 check_handle_resolution.pl %{buildroot}/%{_libexecdir}/argo/probes/eudat-b2handle/check_handle_resolution.pl
+install -m 644 check_handle_api.py %{buildroot}%{_libexecdir}/argo/probes/eudat-b2handle/check_handle_api.py
+%if %{with epicapi}
 install -m 755 check_epic_api.py %{buildroot}/%{_libexecdir}/argo/probes/eudat-b2handle/check_epic_api.py
 install -m 644 epicclient.py %{buildroot}%{_libexecdir}/argo/probes/eudat-b2handle/epicclient.py
-install -m 644 check_handle_api.py %{buildroot}%{_libexecdir}/argo/probes/eudat-b2handle/check_handle_api.py
+%py_byte_compile %{__python3} %{buildroot}%{_libexecdir}/argo/probes/eudat-b2handle/epicclient.py
+%endif
 
 %files
 %dir /%{_libexecdir}/argo
@@ -45,15 +50,22 @@ install -m 644 check_handle_api.py %{buildroot}%{_libexecdir}/argo/probes/eudat-
 %dir /%{_libexecdir}/argo/probes/eudat-b2handle
 
 %attr(0755,root,root) /%{_libexecdir}/argo/probes/eudat-b2handle/check_handle_resolution.pl
+%attr(0755,root,root) /%{_libexecdir}/argo/probes/eudat-b2handle/check_handle_api.py
+%if %{with epicapi}
 %attr(0755,root,root) /%{_libexecdir}/argo/probes/eudat-b2handle/check_epic_api.py
 %attr(0755,root,root) /%{_libexecdir}/argo/probes/eudat-b2handle/epicclient.py
-%attr(0644,root,root) /%{_libexecdir}/argo/probes/eudat-b2handle/epicclient.pyc
-%attr(0644,root,root) /%{_libexecdir}/argo/probes/eudat-b2handle/epicclient.pyo
-%attr(0755,root,root) /%{_libexecdir}/argo/probes/eudat-b2handle/check_handle_api.py
+%attr(0644,root,root) /%{_libexecdir}/argo/probes/eudat-b2handle/__pycache__
+%endif
 
 %pre
 
 %changelog
+* Thu Apr 18 2024 Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 1.0-0
+- Added support for python3
+- Handle API probe uses pyhandle library instead of b2handle
+- Handle API probe prints more debugging output when called with --debug
+- EPIC API probe is optional
+
 * Mon Mar 14 2022 Themis Zamani <themiszamani@gmail.com> - 0.9-4
 - Update package prerequisites based on argo monitoring. 
   

--- a/check_epic_api.py
+++ b/check_epic_api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import sys
@@ -13,7 +13,7 @@ VALUE_ORIG='http://www.' + TEST_SUFFIX + '.com/1'
 VALUE_AFTER='http://www.' + TEST_SUFFIX + '.com/2'
 
 def handler(signum, stack):
-    print "UNKNOWN: Timeout reached, exiting."
+    print("UNKNOWN: Timeout reached, exiting.")
     sys.exit(3)
 
 if __name__ == '__main__':
@@ -58,9 +58,9 @@ if __name__ == '__main__':
             None, TEST_SUFFIX)
 
         if create_result == str(cred.prefix + '/' + TEST_SUFFIX):
-            print "OK: Create handle successful."
+            print("OK: Create handle successful.")
         else:
-            print "CRITICAL: Create handle returned unexpected response."
+            print("CRITICAL: Create handle returned unexpected response.")
             sys.exit(2)
     
         # Read test
@@ -69,9 +69,9 @@ if __name__ == '__main__':
             cred.prefix, 'URL', TEST_SUFFIX)
   
         if read_value == VALUE_ORIG:
-            print "OK: Read handle successful."
+            print("OK: Read handle successful.")
         else:
-            print "CRITICAL: Read handle returned unexpected response."
+            print("CRITICAL: Read handle returned unexpected response.")
             client.deleteHandle(cred.prefix, '', TEST_SUFFIX)
             sys.exit(2)
 
@@ -82,7 +82,7 @@ if __name__ == '__main__':
             cred.prefix, key, VALUE_AFTER, TEST_SUFFIX)
 
         if not modify_result:
-            print "CRITICAL: Modify handle value returned unexpected response."
+            print("CRITICAL: Modify handle value returned unexpected response.")
             client.deleteHandle(cred.prefix, '', TEST_SUFFIX)
             sys.exit(2)
 
@@ -90,11 +90,11 @@ if __name__ == '__main__':
             cred.prefix, key, TEST_SUFFIX)
 
         if get_value_result == VALUE_AFTER:
-            print "OK: Modify handle successful."
+            print("OK: Modify handle successful.")
         else:
-            print "CRITICAL: Modify handle value returned unexpected value."
-            print "Expected : " + VALUE_AFTER
-            print "Returned : " + get_value_result
+            print("CRITICAL: Modify handle value returned unexpected value.")
+            print("Expected : " + VALUE_AFTER)
+            print("Returned : " + get_value_result)
             client.deleteHandle(cred.prefix, '', TEST_SUFFIX)
             sys.exit(2)
 
@@ -103,14 +103,14 @@ if __name__ == '__main__':
         delete_result = client.deleteHandle(cred.prefix, '', TEST_SUFFIX)
 
         if delete_result:
-            print "OK: Delete handle successful."
+            print("OK: Delete handle successful.")
             sys.exit(0)
         else:
-            print "CRITICAL: Delete existing handle returned unexpected response."
+            print("CRITICAL: Delete existing handle returned unexpected response.")
             sys.exit(2)
 
     except Exception as e:
-        print "UNKNOWN: " + e
+        print("UNKNOWN: " + str(e))
         sys.exit(3)
     
 

--- a/check_handle_api.py
+++ b/check_handle_api.py
@@ -1,24 +1,28 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+# Kyriakos Gkinis <kyrginis@admin.grnet.gr>, 2017
 
 import argparse
+import logging
 import sys
-import b2handle
-import traceback
-from b2handle.clientcredentials import PIDClientCredentials
-from b2handle.handleclient import EUDATHandleClient
-from b2handle.handleexceptions import *
-from requests.exceptions import SSLError
-
 import signal
+import time
+import traceback
 
-from time import strftime,gmtime
+from requests.exceptions import SSLError
+from requests.packages.urllib3 import disable_warnings
 
-TEST_SUFFIX='NAGIOS-' +  strftime("%Y%m%d-%H%M%S",gmtime())
+from pyhandle.clientcredentials import PIDClientCredentials
+from pyhandle.handleclient import PyHandleClient
+import pyhandle.handleexceptions as hdlex
+
+
+TEST_SUFFIX='NAGIOS-' +  time.strftime("%Y%m%d-%H%M%S",time.gmtime())
 VALUE_ORIG='http://www.' + TEST_SUFFIX + '.com/1'
 VALUE_AFTER='http://www.' + TEST_SUFFIX + '.com/2'
 
 def handler(signum, stack):
-    print "UNKNOWN: Timeout reached, exiting."
+    print("UNKNOWN: Timeout reached, exiting.")
     sys.exit(3)
 
 if __name__ == '__main__':
@@ -39,11 +43,21 @@ if __name__ == '__main__':
         signal.signal(signal.SIGALRM, handler)
         signal.alarm(int(param.timeout))
 
+    if param.debug:
+        logging.basicConfig(level=logging.DEBUG)
+
     try:
 
-        print "Creating credentials"
+        print("Creating credentials")
         cred = PIDClientCredentials.load_from_JSON(param.json_file)
-        client = EUDATHandleClient.instantiate_with_credentials(cred)
+        client = PyHandleClient("rest").instantiate_with_credentials(cred)
+
+        all_creds = cred.get_all_args()
+
+        # If not in debug mode, disable InsecureRequestWarnings when "HTTPS_verify": "False"
+        if (not param.debug and 'HTTPS_verify' in all_creds
+                and all_creds['HTTPS_verify'].lower()=='false'):
+            disable_warnings() 
 
         print('PID prefix ' + cred.get_prefix())
         print('Server ' + cred.get_server_URL())
@@ -51,14 +65,14 @@ if __name__ == '__main__':
         handle = cred.get_prefix() + '/' + TEST_SUFFIX
         
         # Create test
-        print "Creating handle " + handle
+        print("Creating handle " + handle)
         create_result = client.register_handle(
             handle, VALUE_ORIG)
 
         if create_result == handle:
-            print "OK: Create handle successful."
+            print("OK: Create handle successful.")
         else:
-            print "CRITICAL: Create handle returned unexpected response."
+            print("CRITICAL: Create handle returned unexpected response.")
             sys.exit(2)
          
         # Read test
@@ -66,10 +80,13 @@ if __name__ == '__main__':
         read_value = client.get_value_from_handle(
             handle, key)
         
+        if param.debug:
+            print("DEBUG:Handle value after Create operation: " + read_value)
+
         if read_value == VALUE_ORIG:
-            print "OK: Read handle successful."
+            print("OK: Read handle successful.")
         else:
-            print "CRITICAL: Read handle returned unexpected response."
+            print("CRITICAL: Read handle returned unexpected response.")
             client.delete_handle(handle)
             sys.exit(2)
         
@@ -80,31 +97,36 @@ if __name__ == '__main__':
         get_value_result = client.get_value_from_handle(
             handle, key)
 
+        if param.debug:
+            print("DEBUG:Handle value after Modify operation: " + get_value_result)
+
         if get_value_result == VALUE_AFTER:
-            print "OK: Modify handle successful."
+            print("OK: Modify handle successful.")
         else:
-            print "CRITICAL: Modify handle value returned unexpected value."
-            print "Expected : " + VALUE_AFTER
-            print "Returned : " + get_value_result
+            print("CRITICAL: Modify handle value returned unexpected value.")
+            print("Expected : " + VALUE_AFTER)
+            print("Returned : " + get_value_result)
             client.delete_handle(handle)
             sys.exit(2)
         
         # Delete test
 
         delete_result = client.delete_handle(handle)
-        print "OK: Delete handle successful."
+        print("OK: Delete handle successful.")
         
-    except (GenericHandleError, CredentialsFormatError, HandleSyntaxError, HandleNotFoundException, HandleAuthenticationError, SSLError) as e:
+    except (hdlex.GenericHandleError, hdlex.CredentialsFormatError, hdlex.HandleAlreadyExistsException,
+                hdlex.HandleSyntaxError, hdlex.HandleNotFoundException, hdlex.HandleAuthenticationError,
+                SSLError) as e:
         if param.debug :
-            print "CRITICAL: " + traceback.format_exc()
+            print("CRITICAL: " + traceback.format_exc())
         else :
-            print "CRITICAL: " + str(e)
+            print("CRITICAL: " + str(e))
         sys.exit(2)
     except Exception as e:
         if param.debug :
-            print "UNKNOWN: " + traceback.format_exc()
+            print("UNKNOWN: " + traceback.format_exc())
         else:
-            print "UNKNOWN: " + str(e)
+            print("UNKNOWN: " + str(e))
         sys.exit(3)
     
 

--- a/epicclient.py
+++ b/epicclient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 # Copyright (c) 2014, EUDAT project funded from the European Union under grant agreement n.283304.
@@ -102,7 +102,7 @@ class EpicClient(object):
         """Internal: Print a debug message if debug is enabled."""
 
         if self.debug:
-            print "[", method, "]", msg
+            print("[", method, "]", msg)
 
     def _geturi(self, prefix, key, value, suffix=''):
         """
@@ -124,23 +124,22 @@ class EpicClient(object):
             build Header for HTTP-Request
         """
         hdrs = None
-        auth = base64.encodestring(self.cred.username + ":" +
-                                   self.cred.password)
-        if action is "SEARCH":
+        auth = base64.b64encode((self.cred.username + ":" + self.cred.password).encode()).decode()
+        if action == "SEARCH":
             if self.cred.accept_format:
                 hdrs = {'Accept': self.cred.accept_format,
                         'Authorization': 'Basic ' + auth}
-        elif action is "READ":
+        elif action == "READ":
             if self.cred.accept_format:
                 hdrs = {'Accept': self.cred.accept_format,
                         'Authorization': 'Basic ' + auth}
-        elif action is "CREATE":
+        elif action == "CREATE":
             hdrs = {'If-None-Match': '*', 'Content-Type': 'application/json',
                     'Authorization': 'Basic ' + auth}
-        elif action is "UPDATE":
+        elif action == "UPDATE":
             hdrs = {'Content-Type': 'application/json',
                     'Authorization': 'Basic ' + auth}
-        elif action is "DELETE":
+        elif action == "DELETE":
             hdrs = {'Authorization': 'Basic ' + auth}
         else:
             self._debugmsg(str(action), "ACTION is unknown")
@@ -181,13 +180,13 @@ class EpicClient(object):
                 self._debugmsg("checkresponsecode", ".....")
                 self._debugmsg(str(method), item["info"]+" "+str(statuscode))
                 output = item["output"]
-                if output is "None":
+                if output == "None":
                     return None
-                elif output is "False":
+                elif output == "False":
                     return False
                 else:
                     return True
-        print "Processing fails with statuscode = " + str(statuscode)
+        print("Processing fails with statuscode = " + str(statuscode))
         return None
 
 
@@ -374,7 +373,7 @@ class EpicClient(object):
 
         keyfound = False
 
-        if (value is None) or (value is '') or (value is ""):
+        if (value is None) or (value == '') or (value == ""):
             for item in handle:
                 if 'type' in item and item['type'] == key:
                     self._debugmsg('modifyHandle', 'Remove item ' + key)
@@ -421,7 +420,7 @@ class EpicClient(object):
         """
 
         uri = self._geturi(prefix, '', '', suffix)
-        if not key or key is "":
+        if not key or key == "":
             hdrs = self._getheader("DELETE")
             self._debugmsg('deleteHandle', "DELETE Handle " + prefix + "/"
                            + suffix + " of URI " + uri)
@@ -615,7 +614,7 @@ class LocationType(object):
         """Internal: Print a debug message if debug is enabled."""
 
         if self.debug:
-            print "[", method, "]", msg
+            print("[", method, "]", msg)
 
     def isEmpty(self):
         """Check if the 10320/LOC handle type field is empty.
@@ -783,8 +782,7 @@ class Credentials(object):
             try:
                 filehandle = open(self.filename, "r")
             except IOError as err:
-                print "error: failed to open %s: %s" % (self.filename,
-                                                        err.strerror)
+                print("error: failed to open %s: %s" % (self.filename, err.strerror))
                 sys.exit(-1)
 
             with filehandle:
@@ -802,21 +800,21 @@ class Credentials(object):
                 if tmp['debug'] == 'True':
                     self.debug = True
             except KeyError:
-                print "error: missing key-value-pair in credentials file"
+                print("error: missing key-value-pair in credentials file")
                 sys.exit(-1)
 
         elif self.store == "irods":
-            print "Function getting credential store in iRODS is in testing ..."
+            print("Function getting credential store in iRODS is in testing ...")
             # FIXME: is there better way to exit ?.
             sys.exit(-1)
         else:
-            print "error: invalid store '%s', aborting" % self.store
+            print("error: invalid store '%s', aborting" % self.store)
             sys.exit(-1)
 
         if self.debug:
-            print ("credentials from %s:%s %s %s %s" %
+            print(("credentials from %s:%s %s %s %s" %
                    (self.store, self.baseuri, self.username, self.prefix,
-                    self.accept_format))
+                    self.accept_format)))
 
 
 ###############################################################################


### PR DESCRIPTION
Python probes have migrated to Python 3.9.
Handle API probe switched to PyHandle library instead of b2handle library.
Handle API probe prints more debugging output when called with --debug.
EPIC API probe no longer included in the RPM package by default (can be optionally included).
Updated README.md.
Bumped version to 1.0-0.