### PR TITLE
Handle API probe adds UUID string to test handle name, to ensure uniqueness of name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Three nagios probes are available: `check_handle_api.py`, `check_handle_resoluti
 
 ## check_handle_api.py
 
-This plugin is a simple CRUD test of the Handle v8 JSON REST API service on the specified host and the specified prefix. It creates a handle named NAGIOS-{DATE}-{TIME}, and then tries to read it and update it with a new value, and finally tries to delete it.
+This plugin is a simple CRUD test of the Handle v8 JSON REST API service on the specified host and the specified prefix. It creates a handle named NAGIOS-{DATE}-{TIME}-{UUID}, and then tries to read it and update it with a new value, and finally tries to delete it.
 
 It uses the PyHandle library (https://github.com/EUDAT-B2HANDLE/PYHANDLE).
 

--- a/argo-probe-eudat-b2handle.spec
+++ b/argo-probe-eudat-b2handle.spec
@@ -1,6 +1,6 @@
 Name:		argo-probe-eudat-b2handle
-Version:	1.0
-Release:	1%{?dist}
+Version:	1.1
+Release:	0%{?dist}
 Summary:	Monitoring Metrics for B2HANDLE 
 License:	GPLv3+
 Packager:	Kyriakos Gkinis <kyrginis@admin.grnet.gr>
@@ -60,6 +60,9 @@ install -m 644 epicclient.py %{buildroot}%{_libexecdir}/argo/probes/eudat-b2hand
 %pre
 
 %changelog
+* Fri May 2 2025 Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 1.1-0
+- Handle API probe adds UUID string to test handle name
+
 * Thu Apr 18 2024 Kyriakos Gkinis <kyrginis@admin.grnet.gr> - 1.0-0
 - Added support for python3
 - Handle API probe uses pyhandle library instead of b2handle

--- a/check_handle_api.py
+++ b/check_handle_api.py
@@ -8,6 +8,7 @@ import sys
 import signal
 import time
 import traceback
+import uuid
 
 from requests.exceptions import SSLError
 from requests.packages.urllib3 import disable_warnings
@@ -17,7 +18,7 @@ from pyhandle.handleclient import PyHandleClient
 import pyhandle.handleexceptions as hdlex
 
 
-TEST_SUFFIX='NAGIOS-' +  time.strftime("%Y%m%d-%H%M%S",time.gmtime())
+TEST_SUFFIX='NAGIOS-' +  time.strftime("%Y%m%d-%H%M%S",time.gmtime()) + str(uuid.uuid4())
 VALUE_ORIG='http://www.' + TEST_SUFFIX + '.com/1'
 VALUE_AFTER='http://www.' + TEST_SUFFIX + '.com/2'
 


### PR DESCRIPTION
Handle API probe adds UUID string to test handle name, to ensure uniqueness of name.
Updated README.md and SPEC.
Bumped version to 1.1-0.